### PR TITLE
Fix 404 permalink and url

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "404"
-permalink: /404
+permalink: /404.html
 comments: false
 ---
 <p>There doesn't appear to be anything here. Sorry about that.</p>

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ logo:               'assets/img/logo.png'
 background:         'assets/img/placeholder-big.jpg'
 tiled_bg:           false   # Set this true if you want to tile your background image, otherwise it will be covered
 locale:             en_US
-url:                https://abhiii29.github.io/
+url:                https://abhiii29.github.io
 
 # Jekyll
 permalink:          /:title/


### PR DESCRIPTION
## Summary
- correct the 404 page permalink so GitHub Pages recognizes it
- remove the trailing slash from `url` in the Jekyll config

## Testing
- `bundle exec jekyll build` *(fails: cannot load rexml/parsers/baseparser)*

------
https://chatgpt.com/codex/tasks/task_e_683fed5d3a6c832d953874ad74dc68ef