### PR TITLE
Fix typo in Moon theme post

### DIFF
--- a/_posts/2016-03-21-moon-theme.md
+++ b/_posts/2016-03-21-moon-theme.md
@@ -138,7 +138,7 @@ You can set feature image per post. Just add `feature: some link` to your post's
 ```
 feature: /assets/img/some-image.png
 or
-feaure: http://example.com/some-image.png
+feature: http://example.com/some-image.png
 ```    
  This also will be used for twitter card:
 


### PR DESCRIPTION
## Summary
- fix `feaure` typo in Moon theme post

## Testing
- `bundle install`
- `bundle exec jekyll build` *(fails: cannot load such file -- rexml/parsers/baseparser)*

------
https://chatgpt.com/codex/tasks/task_e_683fee9654d0832d9eaca05d8510fe24