### PR TITLE
Fix comment typo in head

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,7 +23,7 @@
     <meta property="og:site_name" content="{{ site.title }}">
     <meta property="og:image" content="{{ site.url }}/{{ site.logo }}">
     {% if site.google.verify %}
-    <!-- Webmaster Tools verfication -->
+    <!-- Webmaster Tools verification -->
     <meta name="google-site-verification" content="{{ site.google.verify }}">{% endif %}
     {% if site.bing-verify %}    <meta name="msvalidate.01" content="{{ site.bing-verify }}">{% endif %}
     {% capture canonical %}{{ site.url }}{% if site.permalink contains '.html' %}{{ page.url }}{% else %}{{ page.url | remove:'index.html' | strip_slash }}{% endif %}{% endcapture %}


### PR DESCRIPTION
## Summary
- fix misspelled comment in `_includes/head.html`

## Testing
- `bundle exec jekyll build` *(fails: `bundler: command not found: jekyll`)*
- `bundle install` *(installs gems)*

------
https://chatgpt.com/codex/tasks/task_e_683feeb26fc0832da5e94e4dec0e0a76