### PR TITLE
Add Jekyll build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build Jekyll site
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
+      - name: Build site
+        run: bundle exec jekyll build

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ gem "jekyll-sitemap"
 gem "jekyll-gist"
 gem 'jekyll-mentions'
 gem 'jekyll-feed'
+# REXML was removed from Ruby 3.x standard library so add it explicitly
+gem 'rexml'

--- a/_config.yml
+++ b/_config.yml
@@ -74,5 +74,3 @@ jekyll-mentions:
 
 # Exclude list
 exclude: [README.md, Gemfile, Gemfile.lock, node_modules, gulpfile.js, package.json, _site, src, vendor, CNAME, LICENSE, Rakefile]
-
-theme: jekyll-theme-cayman


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `jekyll build`
- add missing `rexml` gem for Ruby 3.x
- use Ruby 2.7 and drop the theme line so Jekyll 3.2.1 can build

## Testing
- `bundle install` *(dependency resolution succeeds)*
- `bundle exec jekyll build` *(fails: command not found because bundler executables were cleaned)*


------
https://chatgpt.com/codex/tasks/task_e_683feeb35bb8832da557b8fd447cd5e6